### PR TITLE
Updated the api/project/[name] endpoint to always fetch fresh data

### DIFF
--- a/src/pages/api/repo/[name].ts
+++ b/src/pages/api/repo/[name].ts
@@ -44,22 +44,19 @@ export const handleProjectLookUp = async (
 
     if (repoInDb) {
 
-        if (liveUrlType === 'dynamic') {
-            // get fresh data from GitHub
-            const gitHubData = await gitHubAPI.getRepoByName(name as string, 'dynamic');
-            const { data } = gitHubData;
 
-            // update database with fresh data
-            const updatedRepo = await updateProjectBy.name(name as string, {
-                ...data
-            });
+        // get fresh data from GitHub
+        const gitHubData = await gitHubAPI.getRepoByName(name as string, 'dynamic');
+        const { data } = gitHubData;
 
-            // return updated data to the client
-            return res.status(HttpStatus.OK).json({ data: updatedRepo._doc });
-        }
+        // update database with fresh data
+        const updatedRepo = await updateProjectBy.name(name as string, {
+            ...data
+        });
 
-        // non dynamic request, return data from database
-        return res.status(HttpStatus.OK).json({ data: repoInDb });
+        // return updated data to the client
+        return res.status(HttpStatus.OK).json({ data: updatedRepo._doc });
+
     } else {
         // Repo doesn't exist in database yet let's add it
         const repo = await gitHubAPI.getRepoByName(name as string,


### PR DESCRIPTION
from GitHub, regardless if it is a dynamic request or not.
Dynamic Requests are used for all attache projects. While the default
landing page uses the static version of the endpoint, telling it
where to look for the DEMO URL. On the static version, if the data were
in the database, it wouldn't be updated unless it was added again as
a project in an attache. This could cause changes not to show, so it has
been changed for now. It could be improved upon in the future by
implementing a permanent cache; for now, the implemented cache is
volatile.