### PR TITLE
Updated date on license file.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022 Anthony T
+Copyright (c) 2023 Anthony T
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The deployed site isn't updating the pinned repos as it should. They are updating locally if I change a pinned Repo but not on the deployed site.

There is no reason I can see why this would be happening, we query a list of repo names then look them up. This list of names is what isn't updating.